### PR TITLE
moznost ododvzdat aj po termine

### DIFF
--- a/seminare/rules/fks.py
+++ b/seminare/rules/fks.py
@@ -168,8 +168,7 @@ class FX2026(PreviousProblemSetRuleEngine, BestSubmitRuleEngine, RuleEngine):
         problem: "Problem",
         enrollment: Enrollment | None,
     ) -> bool:
-        if timezone.now() > self.problem_set.end_date:
-            return False
+
 
         return super().can_submit(submit_cls, problem, enrollment)
 


### PR DESCRIPTION
odstránenie podmienky, aby mohli odovzdávať aj po termíne a nemuseli posielať maily