### PR TITLE
fix: move profile section in mobile navbar to top

### DIFF
--- a/seminare/content/templatetags/navbar.py
+++ b/seminare/content/templatetags/navbar.py
@@ -49,7 +49,9 @@ def navbar_menu(context):
         )
 
         items.extend(
-            MenuItem.objects.filter(group__contest=contest).select_related("group").all()
+            MenuItem.objects.filter(group__contest=contest)
+            .select_related("group")
+            .all()
         )
 
     return context


### PR DESCRIPTION
Finish fixing #117 by moving the "my profile" and "logout" section to top of navbar when logged in in mobile view.

fixes #117 